### PR TITLE
Install and Implement vue-router, move date logic to helpers file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10825,6 +10825,11 @@
         "vue-style-loader": "^4.1.0"
       }
     },
+    "vue-router": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.4.tgz",
+      "integrity": "sha512-pX2BGvZg5/MOXbJoYsRppoZM+0B4LSszvIXQvLPZ7govbgbBorYQ4JHx99lDTjzEBkbTyKfRG+ru1VCnMuVcUg=="
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "luxon": "^1.21.3",
     "vue": "^2.6.10",
     "vue-datetime": "^1.0.0-beta.11",
+    "vue-router": "^3.1.4",
     "vuex": "^3.1.2",
     "weekstart": "^1.0.1"
   },

--- a/router.js
+++ b/router.js
@@ -1,0 +1,22 @@
+import Vue from 'vue';
+import Router from 'vue-router';
+import Home from './src/Views/Home.vue';
+import PhotosOfTheMonth from './src/Views/PhotosOfTheMonth.vue';
+
+Vue.use(Router);
+
+export default new Router({
+  mode: 'history',
+  base: process.env.BASE_URL,
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: Home
+    },
+    {
+      path: '/photos-of-the-month',
+      component: PhotosOfTheMonth
+    }
+  ]
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,24 +1,31 @@
 <template>
   <div id="app">
     <NavBar />
-    <PhotoDetail v-bind:current="current" v-bind:date="displayDate" />
-    <MonthContainer v-bind:photos="monthsPhotos" />
+    <router-view>
+      
+    </router-view>
+    <!-- <PhotoDetail v-bind:current="current" v-bind:date="displayDate" /> -->
+    <!-- <MonthContainer v-bind:photos="monthsPhotos" /> -->
   </div>
 </template>
 
 <script>
 import 'es6-promise/auto';
 import NavBar from './components/NavBar.vue';
-import PhotoDetail from './components/PhotoDetail.vue';
-import MonthContainer from './components/MonthContainer.vue';
+import Home from './Views/Home.vue';
+import PhotosOfTheMonth from './Views/PhotosOfTheMonth.vue';
+// import PhotoDetail from './components/PhotoDetail.vue';
+// import MonthContainer from './components/MonthContainer.vue';
 import { getTodaysPhoto, getPotdRange } from './utils/apiCalls/apiCalls.js';
 
 export default {
   name: 'app',
   components: {
+    Home,
     NavBar,
-    PhotoDetail,
-    MonthContainer
+    PhotosOfTheMonth
+    // PhotoDetail,
+    // MonthContainer
   },
   data() {
     return {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,7 @@
 <template>
   <div id="app">
     <NavBar />
-    <router-view>
-      
-    </router-view>
-    <!-- <PhotoDetail v-bind:current="current" v-bind:date="displayDate" /> -->
-    <!-- <MonthContainer v-bind:photos="monthsPhotos" /> -->
+    <router-view> </router-view>
   </div>
 </template>
 
@@ -14,9 +10,6 @@ import 'es6-promise/auto';
 import NavBar from './components/NavBar.vue';
 import Home from './Views/Home.vue';
 import PhotosOfTheMonth from './Views/PhotosOfTheMonth.vue';
-// import PhotoDetail from './components/PhotoDetail.vue';
-// import MonthContainer from './components/MonthContainer.vue';
-import { getTodaysPhoto, getPotdRange } from './utils/apiCalls/apiCalls.js';
 
 export default {
   name: 'app',
@@ -24,53 +17,6 @@ export default {
     Home,
     NavBar,
     PhotosOfTheMonth
-    // PhotoDetail,
-    // MonthContainer
-  },
-  data() {
-    return {
-      current: {},
-      monthsPhotos: [],
-      displayDate: ''
-    };
-  },
-  methods: {
-    async setTodayPhoto() {
-      try {
-        let photo = await getTodaysPhoto();
-        this.current = photo;
-      } catch (error) {
-        null;
-      }
-    },
-    async setMonthlyPhotos() {
-      try {
-        let today = this.getTodaysDate();
-        let currentMonthAndYear = this.getMonthAndYear();
-        let photos = await getPotdRange(`${currentMonthAndYear}-01`, today);
-        this.monthsPhotos = photos;
-      } catch (error) {
-        null;
-      }
-    },
-    getTodaysDate() {
-      let today = new Date();
-      const dd = String(today.getDate()).padStart(2, '0');
-      const mm = String(today.getMonth() + 1).padStart(2, '0');
-      const yyyy = today.getFullYear();
-      this.displayDate = `${mm}/${dd}/${yyyy}`;
-      return `${yyyy}-${mm}-${dd}`;
-    },
-    getMonthAndYear() {
-      let today = new Date();
-      const mm = String(today.getMonth() + 1).padStart(2, '0');
-      const yyyy = today.getFullYear();
-      return `${yyyy}-${mm}`;
-    }
-  },
-  mounted() {
-    this.setTodayPhoto();
-    this.setMonthlyPhotos();
   }
 };
 </script>

--- a/src/Views/Home.vue
+++ b/src/Views/Home.vue
@@ -1,11 +1,45 @@
 <template>
   <div>
     <h1>Photo of the Day</h1>
-    <MonthContainer />
+    <PhotoDetail v-bind:current="current" />
   </div>
 </template>
 
 <script>
-import MonthContainer from '../components/MonthContainer.vue';
-export default {};
+import PhotoDetail from '../components/PhotoDetail.vue';
+import { getTodaysPhoto } from '../utils/apiCalls/apiCalls';
+
+export default {
+  name: 'Home',
+  components: {
+    PhotoDetail
+  },
+  data() {
+    return {
+      current: {},
+      displayDate: ''
+    };
+  },
+  methods: {
+    async setTodayPhoto() {
+      try {
+        let photo = await getTodaysPhoto();
+        this.current = photo;
+      } catch (error) {
+        null;
+      }
+    }
+  },
+  mounted() {
+    this.setTodayPhoto();
+  }
+};
 </script>
+
+<style scoped>
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/src/Views/Home.vue
+++ b/src/Views/Home.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <h1>Photo of the Day</h1>
+    <MonthContainer />
+  </div>
+</template>
+
+<script>
+import MonthContainer from '../components/MonthContainer.vue';
+export default {};
+</script>

--- a/src/Views/PhotosOfTheMonth.vue
+++ b/src/Views/PhotosOfTheMonth.vue
@@ -1,11 +1,47 @@
 <template>
   <div>
     <h1>Photos of the Month</h1>
-    <MonthContainer />
+    <MonthContainer v-bind:photos="monthsPhotos" />
   </div>
 </template>
 
 <script>
 import MonthContainer from '../components/MonthContainer.vue';
-export default {};
+import { getPotdRange } from '../utils/apiCalls/apiCalls';
+import { getTodaysDate, getMonthAndYear } from '../utils/helpers/helpers.js';
+
+export default {
+  name: 'PhotosOfTheMonth',
+  components: {
+    MonthContainer
+  },
+  data() {
+    return {
+      monthsPhotos: []
+    };
+  },
+  methods: {
+    async setMonthlyPhotos() {
+      try {
+        let today = getTodaysDate();
+        let currentMonthAndYear = getMonthAndYear();
+        let photos = await getPotdRange(`${currentMonthAndYear}-01`, today);
+        this.monthsPhotos = photos;
+      } catch (error) {
+        null;
+      }
+    }
+  },
+  mounted() {
+    this.setMonthlyPhotos();
+  }
+};
 </script>
+
+<style scoped>
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/src/Views/PhotosOfTheMonth.vue
+++ b/src/Views/PhotosOfTheMonth.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <h1>Photos of the Month</h1>
+    <MonthContainer />
+  </div>
+</template>
+
+<script>
+import MonthContainer from '../components/MonthContainer.vue';
+export default {};
+</script>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,14 +1,16 @@
 <template>
   <div>
     <h1>Daily Dose of Science</h1>
-    <button>Today's Photo</button>
-    <button>This Month's Photos</button>
+    <router-link to="/">Today's Photo</router-link>
+    <router-link to="/photos-of-the-month">This Month's Photos</router-link>
   </div>
 </template>
 
 <script>
 export default {
-  components: {},
+  components: {
+    name: 'NavBar'
+  },
   data: function() {
     return {
       date: null

--- a/src/components/PhotoDetail.vue
+++ b/src/components/PhotoDetail.vue
@@ -11,10 +11,11 @@
 
 <script>
 import 'es6-promise/auto';
+import { formatTodaysDate } from '../utils/helpers/helpers.js';
 
 export default {
   name: 'PhotoDetail',
-  props: ['current', 'date'],
+  props: ['current'],
   data() {
     return {
       date: ''
@@ -22,8 +23,8 @@ export default {
   },
   methods: {
     formatDate() {
-      let formatted = current.date.toLocaleDateString();
-      this.date = formatted;
+      let todaysDate = formatTodaysDate();
+      this.date = todaysDate;
     }
   },
   mounted() {

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,12 @@
 /* eslint-disable */
 import Vue from 'vue';
-import Vuex from 'vuex';
+import router from '../router';
+
 import App from './App.vue';
 
 Vue.config.productionTip = false;
-Vue.use(Vuex);
 
 new Vue({
+  router,
   render: h => h(App)
 }).$mount('#app');

--- a/src/utils/helpers/helpers.js
+++ b/src/utils/helpers/helpers.js
@@ -1,3 +1,22 @@
 export const formatTodaysDate = () => {
-  const date = require('date-and-time');
+  let today = new Date();
+  const dd = String(today.getDate()).padStart(2, '0');
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const yyyy = today.getFullYear();
+  return `${mm}/${dd}/${yyyy}`;
+};
+
+export const getTodaysDate = () => {
+  let today = new Date();
+  const dd = String(today.getDate()).padStart(2, '0');
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const yyyy = today.getFullYear();
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+export const getMonthAndYear = () => {
+  let today = new Date();
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const yyyy = today.getFullYear();
+  return `${yyyy}-${mm}`;
 };


### PR DESCRIPTION
## What does this PR do?
- [x] Installs vue-router
- [x] Creates `router.js` with the two current paths
- [x] Creates two View files to contain components that will be rendered on the two routes
- [x] Moves fetch logic to corresponding View file
- [x] Renders all previously rendered information on either the `/` or `/photos-of-the-month` route
- [x] Moves date formatting logic to `helpers.js`
### Where should the reviewer start?
- [ ] In `router.js`, please note how the instantiation of Router is created
- [ ] In the Views directory, please examine:
  - [ ] `Home.vue` and how the `PhotoDetail.vue` component is now rendered there
  - [ ] `Home.vue` now has the `setTodayPhoto()` method
  - [ ] `PhotosOfTheMonth.vue` and how the `MonthContainer.vue` component is now rendered there
  - [ ] `PhotosOfTheMonth.vue` now has the `setMonthPhotos()` method
### How should this be manually tested?
Pull down, and see if you can navigate to different routes and see the same information as before, but on either the `/` or `/photos-of-the-month` path!
### Have tests been written for all functionality?
No.
### Any background context you want to provide?
N/A
### What are the relevant tickets?
Closes #3 
Closes #9 
Closes #10 
Closes #17 
### Screenshots (if appropriate)
<img width="1439" alt="Screen Shot 2020-01-14 at 11 10 56 PM" src="https://user-images.githubusercontent.com/31895658/72409490-2c9b9c00-3723-11ea-907b-db85f6944048.png">
<img width="1440" alt="Screen Shot 2020-01-14 at 11 11 08 PM" src="https://user-images.githubusercontent.com/31895658/72409491-2c9b9c00-3723-11ea-9f87-ed54c0fe6437.png">

### Additional Notes
N/A